### PR TITLE
Add getCollections method

### DIFF
--- a/services/contentful.coffee
+++ b/services/contentful.coffee
@@ -53,6 +53,12 @@ export getEntry = (payload) ->
 	result = Object.values(data)[0]
 	return flattenEntry result?.items?[0] || result
 
+# Execute a query that gets multiple collections, and return the flattened collections.
+export getCollections = (payload) ->
+	data = await execute payload
+	Object.keys(data).forEach (key) -> data[key] = data[key]?.items.map flattenEntry
+	return data
+
 # Contentful nests each sub collection in an items property. This removes all
 # of the items properties and adds sys.id as the id so:
 # - tower.sys.id -> tower.id


### PR DESCRIPTION
Here's a `getCollections` method that can handle and flatten a GQL query with multiple collections, like this:

```
query getRelatedPodcasts($slug:String, $tag:String) {

  # Get the 2 most recent podcasts with this tag that don't have this slug.
  relatedPodcastsTag: podcastCollection(
    limit: 2,
    order: [date_DESC, featured_DESC],
    where: {
      slug_not: $slug
      contentfulMetadata: {
        tags_exists: true
        tags: { id_contains_some: [$tag] }
      }
    }
  ) {
    items { ...relatedPodcast }
  }

  # Fallback: Also get the 2 most recent podcasts that don't have this slug (but might contain other tags)
  relatedPodcasts: podcastCollection(
    limit: 2,
    order: [date_DESC, featured_DESC],
    where: {
      slug_not: $slug
    }
  ) {
    items { ...relatedPodcast }
  }
}
```