### PR TITLE
Generate fontagon stylus mixins

### DIFF
--- a/build/fontagon-template.hbs
+++ b/build/fontagon-template.hbs
@@ -30,10 +30,17 @@ fontagon-font-path ?= '~assets/fonts/fontagon/dist'
 	/* Support for IE. */
 	font-feature-settings 'liga'
 
-// Begin writing font classes
+// Font classes
 
 {{#each codepoints}}
 .{{../classPrefix}}-{{@key}}
 	&:before
 		content "\\{{this}}"
+{{/each}}
+
+// Stylus mixins (for adding icons to pseudo-elements)
+
+{{#each codepoints}}
+{{../classPrefix}}-{{@key}}()
+	content "\\{{this}}"
 {{/each}}

--- a/build/fontagon-template.hbs
+++ b/build/fontagon-template.hbs
@@ -31,7 +31,8 @@ fontagon-base-styles()
 
 // Make icon class
 [class^="{{classPrefix}}-"], [class*=" {{classPrefix}}-"]
-	fontagon-base-styles()
+	&:before
+		fontagon-base-styles()
 
 // Font classes
 
@@ -39,12 +40,4 @@ fontagon-base-styles()
 .{{../classPrefix}}-{{@key}}
 	&:before
 		content "\\{{this}}"
-{{/each}}
-
-// Stylus mixins (for adding icons to pseudo-elements)
-
-{{#each codepoints}}
-{{../classPrefix}}-{{@key}}()
-	fontagon-base-styles()
-	content "\\{{this}}"
 {{/each}}

--- a/build/fontagon-template.hbs
+++ b/build/fontagon-template.hbs
@@ -9,8 +9,7 @@ fontagon-font-path ?= '~assets/fonts/fontagon/dist'
 	font-style normal
 	font-display block
 
-// Make icon class
-[class^="{{classPrefix}}-"], [class*=" {{classPrefix}}-"]
+fontagon-base-styles()
 	font-family '{{fontName}}' !important
 	speak never
 	font-style normal
@@ -30,6 +29,10 @@ fontagon-font-path ?= '~assets/fonts/fontagon/dist'
 	/* Support for IE. */
 	font-feature-settings 'liga'
 
+// Make icon class
+[class^="{{classPrefix}}-"], [class*=" {{classPrefix}}-"]
+	fontagon-base-styles()
+
 // Font classes
 
 {{#each codepoints}}
@@ -42,5 +45,6 @@ fontagon-font-path ?= '~assets/fonts/fontagon/dist'
 
 {{#each codepoints}}
 {{../classPrefix}}-{{@key}}()
+	fontagon-base-styles()
 	content "\\{{this}}"
 {{/each}}


### PR DESCRIPTION
Let's generate stylus mixins for each icon so that we can add icons to pseudo-elements.   Such adding an arrow icon to an `:after` pseudo-element on a link.  

We'll need to import these mixins into stylus, so I'll add the following to `definitions.styl` in create-cloak-app.  I'll submit a PR for this:
`@import './fonts/fontagon/dist/fontagon'`