### PR TITLE
Site specific redirects

### DIFF
--- a/build/craft-netlify-redirects.js
+++ b/build/craft-netlify-redirects.js
@@ -7,8 +7,8 @@ import { resolve } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 
 // Query for redirects
-const getEntries = `query getRedirects {
-	entries(type:"redirects") {
+const getEntries = `query getRedirects(($site:[String])) {
+	entries(type:"redirects", site:$site) {
 		... on redirects_redirects_Entry {
 			from: redirectFrom
 			to: redirectTo
@@ -26,6 +26,7 @@ export default function() {
 		// Open up _redirects
 		const file = resolve(this.nuxt.options.srcDir, 'dist/_redirects')
 		let redirects = existsSync(file) ? readFileSync(file, 'utf8') : ''
+		let site = process.env.CMS_SITE ? process.env.CMS_SITE : ''
 
 		// Fetch the server side redirects
 		const response = await axios({
@@ -35,7 +36,8 @@ export default function() {
 				'Content-Type': 'application/json'
 			},
 			data: {
-				query: getEntries
+				query: getEntries,
+				site: site
 			}
 		});
 

--- a/build/craft-netlify-redirects.js
+++ b/build/craft-netlify-redirects.js
@@ -7,7 +7,7 @@ import { resolve } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 
 // Query for redirects
-const getEntries = `query getRedirects(($site:[String])) {
+const getEntries = `query getRedirects($site:[String]) {
 	entries(type:"redirects", site:$site) {
 		... on redirects_redirects_Entry {
 			from: redirectFrom

--- a/build/craft-netlify-redirects.js
+++ b/build/craft-netlify-redirects.js
@@ -26,7 +26,14 @@ export default function() {
 		// Open up _redirects
 		const file = resolve(this.nuxt.options.srcDir, 'dist/_redirects')
 		let redirects = existsSync(file) ? readFileSync(file, 'utf8') : ''
-		let site = process.env.CMS_SITE ? process.env.CMS_SITE : ''
+		
+		let data = { query: getEntries }
+
+		// if there's a CMS_SITE env var, then add it
+		// I tested this in craft and it didn't like an empty string
+		if (process.env.CMS_SITE) {
+			data.site = process.env.CMS_SITE
+		}
 
 		// Fetch the server side redirects
 		const response = await axios({
@@ -35,10 +42,7 @@ export default function() {
 			headers: {
 				'Content-Type': 'application/json'
 			},
-			data: {
-				query: getEntries,
-				site: site
-			}
+			data: data
 		});
 
 		// Write redirects file back out

--- a/build/craft-netlify-redirects.js
+++ b/build/craft-netlify-redirects.js
@@ -27,14 +27,6 @@ export default function() {
 		const file = resolve(this.nuxt.options.srcDir, 'dist/_redirects')
 		let redirects = existsSync(file) ? readFileSync(file, 'utf8') : ''
 		
-		let data = { query: getEntries }
-
-		// if there's a CMS_SITE env var, then add it
-		// I tested this in craft and it didn't like an empty string
-		if (process.env.CMS_SITE) {
-			data.site = process.env.CMS_SITE
-		}
-
 		// Fetch the server side redirects
 		const response = await axios({
 			url: process.env.CMS_ENDPOINT,
@@ -42,7 +34,11 @@ export default function() {
 			headers: {
 				'Content-Type': 'application/json'
 			},
-			data: data
+			data: {				query: getEntries,
+				variables: {
+					site: process.env.CMS_SITE || null
+				}
+			}
 		});
 
 		// Write redirects file back out

--- a/build/craft-netlify-redirects.js
+++ b/build/craft-netlify-redirects.js
@@ -26,7 +26,7 @@ export default function() {
 		// Open up _redirects
 		const file = resolve(this.nuxt.options.srcDir, 'dist/_redirects')
 		let redirects = existsSync(file) ? readFileSync(file, 'utf8') : ''
-		
+
 		// Fetch the server side redirects
 		const response = await axios({
 			url: process.env.CMS_ENDPOINT,
@@ -34,7 +34,8 @@ export default function() {
 			headers: {
 				'Content-Type': 'application/json'
 			},
-			data: {				query: getEntries,
+			data: {
+				query: getEntries,
 				variables: {
 					site: process.env.CMS_SITE || null
 				}


### PR DESCRIPTION
@weotch let me know if this looks right to you. 

In Graphiql, it didn't like an empty string for `site`, so I made a second commit to instead only add `site` to the `data` object if the env var existed.