### PR TITLE
first pass at testing for png, and making the bg color default transp…

### DIFF
--- a/components/cloak-visual.coffee
+++ b/components/cloak-visual.coffee
@@ -95,9 +95,9 @@ export default
 		# Clear placeholder color if `no-placeholder` prop is set or if the image
 		# is of a format that woulds support transparency.  The latter is handy
 		# for product images.
-		if props.noPlaceholder or
+		placeholderColor = unless props.noPlaceholder or
 			(props.autoNoPlaceholder and props.image.match /\.(png|svg)/i)
-		then placeholderColor = null
+		then process.env.PLACEHOLDER_COLOR || 'rgba(0,0,0,.2)'
 
 		# Disable lazy loading automatically if found in 2 blocks. Written
 		# kinda weird so it defaults to true when blockIndex is undefined

--- a/components/cloak-visual.coffee
+++ b/components/cloak-visual.coffee
@@ -33,6 +33,9 @@ export default
 
 		# Clear placeholder color, like for logos
 		noPlaceholder: Boolean
+		autoNoPlaceholder:
+			type: Boolean
+			default: true
 
 		# Set base booleans to an undefined default so we can test whether they
 		# were explicitly made false or are actually undefined
@@ -65,14 +68,6 @@ export default
 	# Render a Visual instance
 	render: (create, { props, injections, data, children, scopedSlots }) ->
 
-		# if the file is a PNG, then don't show a placeholder
-		img = props.image?[0]
-		isPng = img?.path.match(/.(png)$/i) || img?.mimeType == 'image/png'
-
-		# Decide if there is a placeholder color
-		placeholderColor = if props.noPlaceholder || isPng then null
-		else process.env.PLACEHOLDER_COLOR || 'rgba(0,0,0,.2)'
-
 		# Convert "16:9" style aspect to a number
 		aspect = if props.aspect and
 			typeof props.aspect == 'string' and
@@ -96,6 +91,13 @@ export default
 		# Warn developers to specify a sizes prop
 		if props.image and !sizes and process.env.APP_ENV == 'dev'
 		then console.debug "No sizes prop for #{props.image}"
+
+		# Clear placeholder color if `no-placeholder` prop is set or if the image
+		# is of a format that woulds support transparency.  The latter is handy
+		# for product images.
+		if props.noPlaceholder or
+			(props.autoNoPlaceholder and props.image.match /\.(png|svg)/i)
+		then placeholderColor = null
 
 		# Disable lazy loading automatically if found in 2 blocks. Written
 		# kinda weird so it defaults to true when blockIndex is undefined

--- a/components/cloak-visual.coffee
+++ b/components/cloak-visual.coffee
@@ -65,9 +65,13 @@ export default
 	# Render a Visual instance
 	render: (create, { props, injections, data, children, scopedSlots }) ->
 
+		# if the file is a PNG, then don't show a placeholder
+		img = props.image?[0]
+		isPng = img?.path.match(/.(png)$/i) || img?.mimeType == 'image/png'
+
 		# Decide if there is a placeholder color
-		placeholderColor = if props.noPlaceholder then null
-		else process.env.PLACEHOLDER_COLOR || '#f3f3f2'
+		placeholderColor = if props.noPlaceholder || isPng then null
+		else process.env.PLACEHOLDER_COLOR || 'rgba(0,0,0,.2)'
 
 		# Convert "16:9" style aspect to a number
 		aspect = if props.aspect and


### PR DESCRIPTION
@weotch first pass at updating the placeholder colors, like we spoke about in the dev meeting

- I've tested the code to determine if it's a png using Drip Drop's craft-visual, since it was an easy place to test
- updating the hex for defaults to be "rgba(0,0,0,.2)"
- Craft does pass the mimeType, so I'm checking for a match of '.png' or if mimeType == 'image/png'

relevant issue
https://github.com/BKWLD/cloak/issues/43