### PR TITLE
Update focus-visible selector

### DIFF
--- a/assets/focus-visible.styl
+++ b/assets/focus-visible.styl
@@ -1,3 +1,3 @@
 // https://github.com/WICG/focus-visible#2-update-your-css
-.js-focus-visible :focus:not(.focus-visible)
+.js-focus-visible :focus:not(.focus-visible, [data-focus-visible-added])
 	outline none

--- a/assets/focus-visible.styl
+++ b/assets/focus-visible.styl
@@ -1,3 +1,3 @@
 // https://github.com/WICG/focus-visible#2-update-your-css
-.js-focus-visible :focus:not(.focus-visible, [data-focus-visible-added])
+[data-js-focus-visible] :focus:not([data-focus-visible-added])
 	outline none


### PR DESCRIPTION
I ran into a situation where Vue was modifying an element's classes, and removing `.focus-visible`, which is fine, so I used the fallback `[data-focus-visible-added]` attribute.  

However, I noticed a bug where Cloak's selector was hiding my element's outline when it had `:focus` and `[data-focus-visible-added]`, but not `.focus-visible`.  This update fixes that situation.

I tested a bunch of combinations to confirm this works as expected:

```
Cloak before PR:
Element has :focus and...

.focus-visible		[data-focus-visible-added]		Shows outline?
No			No					No
Yes			No					Yes
Yes			Yes					Yes
No			Yes					NO <<<

Cloak after PR:  
Element has :focus and...

.focus-visible		[data-focus-visible-added]		Shows outline?
No			No					No
Yes			No					Yes
Yes			Yes					Yes
No			Yes					YES <<<

```