### PR TITLE
Passthrough `total` property on Contentful collections before flattening

### DIFF
--- a/services/contentful.coffee
+++ b/services/contentful.coffee
@@ -102,7 +102,12 @@ export flattenEntry = (entry) ->
 
 			# Flatten `items` and recurse through children
 			when (items = entry[key]?.items) and Array.isArray items
-			then obj[key] = flattenEntries items
+				# If `items` has a `total` property, save it to `{key}Total`
+				# so we don't lose it
+				if (total = entry[key]?.total)?
+					obj["#{key}Total"] = total
+
+				obj[key] = flattenEntries items
 
 			# Otherwise, passthrough the key/val
 			else obj[key] = entry[key]

--- a/services/contentful.coffee
+++ b/services/contentful.coffee
@@ -102,11 +102,13 @@ export flattenEntry = (entry) ->
 
 			# Flatten `items` and recurse through children
 			when (items = entry[key]?.items) and Array.isArray items
-				# If `items` has a `total` property, save it to `{key}Total`
-				# so we don't lose it
-				if (total = entry[key]?.total)?
-					obj["#{key}Total"] = total
 
+				# If `items` has a `total` property, save it to `{key}Total`
+				# so we don't lose it. This can be used for pagination.
+				if (total = entry[key]?.total)?
+				then obj["#{key}Total"] = total
+
+				# Do the flattening
 				obj[key] = flattenEntries items
 
 			# Otherwise, passthrough the key/val


### PR DESCRIPTION
To workaround Contentful complexity limit, I need to fetch tower blocks in chunks of 10.  I need to know the total number of blocks so I know whether to fetch more.  Contentful provides a [total property on collections fields](https://www.contentful.com/developers/docs/references/graphql/#/reference/collection-fields/return-value), but Cloak discards this when it does its flattening.   In this PR, Cloak checks if `total` was queried, and if the property exists it saves it to `{key}Total`.  For example on a tower query this makes a `blocksTotal` property.