### PR TITLE
Add fetchKey prop

### DIFF
--- a/components/rich-text/rich-text.coffee
+++ b/components/rich-text/rich-text.coffee
@@ -23,7 +23,16 @@ export default
 		unorphan: Boolean
 		balanceText: Boolean
 
+		# Optional.  For manually setting the fetchKey to something unique
+		# to each component instance.  Use this if you're getting Nuxt fetch key
+		# conflicts.  This can happen after client-side navigation in static mode.
+		# Can cause your rich-text 'links' to get nulled out, or the message
+		# to appear: "Missing renderer for undefined".
+		fetchKey: String
+
 	data: -> links: {}
+
+	fetchKey: (getCounter) -> @fetchKey or getCounter()
 
 	# Fetch linked entries
 	fetch: ->


### PR DESCRIPTION
I had a situation in HFO where in static mode, after client-side navigation, the embedded entries inside my `rich-text` components were going missing, and instead showing "Missing renderer for undefined".   On further inspection, this was because the `links` data property, initialized in the fetch hook, was becoming null after client-side navigation.  When I manually set the `rich-text` `fetchKey` property to something unique, the behavior goes away.  This makes me think it was caused by a fetchKey conflict.  

To solve this, the best solution I can think of is to expose a `fetchKey` prop in `rich-text`, allowing the consumer to provide a fetchKey unique to each component instance.  I think in most cases this prop can be omitted (the PR includes a fallback to the default `getCounter()`), and the prop will only be used in edge cases like this where it's needed.

Steps to reproduce the broken behavior:

- Checkout [HFO master branch](https://gitlab.com/happy-family-organics/happyfamilyorganics.com)
- In package.json, change cloak to point to the master branch.
- Yarn install
- Change `nuxt.config` to generate only the homepage tower
- Run `yarn generate --devtools`
- `cd dist; npx serve -p 3000`
- Open the homepage: localhost:3000
- Click to a subpage, click browser back arrow
- Observe: Pill buttons inside blocks do not work, instead show "Missing renderer for undefined"

Steps to reproduce the fixed behavior with this PR:

- In package.json, revert cloak back to this PR branch
- generate and test again

Here's how it gets consumed in a component:

```
rich-text(
	:doc='block.copy'
	:fetch-key='block.id'
)
```

Here's an actual example in HFO: [slide-marquee.vue](https://gitlab.com/happy-family-organics/happyfamilyorganics.com/blob/bc6fe627f941956a29de2af6d340b9dd35536c59/components/blocks/slide-marquee.vue#L37)