### PR TITLE
Add null alt text capabilities to contentful-visual component even if the asset has a title.

### DIFF
--- a/components/contentful-visual.coffee
+++ b/components/contentful-visual.coffee
@@ -70,7 +70,7 @@ export default
 				maxWidth
 
 				# Accessibility
-				alt: if nullAlt then "" else image?.description ||
+				alt: props.alt ? image?.description ||
 					image?.title ||
 					video?.description ||
 					video?.title

--- a/components/contentful-visual.coffee
+++ b/components/contentful-visual.coffee
@@ -22,7 +22,6 @@ export default
 		# Make shorter accessors
 		image = props.image
 		video = props.video
-		nullAlt = (image and image.description == 'null') || (video and video.description == 'null')
 
 		# Get the image src, ignoring srcset for now.  We're using the
 		imageUrl = if props.natural then image?.url

--- a/components/contentful-visual.coffee
+++ b/components/contentful-visual.coffee
@@ -22,6 +22,7 @@ export default
 		# Make shorter accessors
 		image = props.image
 		video = props.video
+		nullAlt = (image and image.description == 'null') || (video and video.description == 'null')
 
 		# Get the image src, ignoring srcset for now.  We're using the
 		imageUrl = if props.natural then image?.url
@@ -70,7 +71,7 @@ export default
 				maxWidth
 
 				# Accessibility
-				alt: image?.description ||
+				alt: if nullAlt then "" else image?.description ||
 					image?.title ||
 					video?.description ||
 					video?.title


### PR DESCRIPTION
Issue: 

The team that performed the SEO audit on HFO's new website requested that decorative images have an empty `alt` attribute. 

Currently, the `contentful-visual.coffee` component defines the `alt` prop that is going to be passed to the `Visual` instance as:
`image?.description || image?.title || video?.description || video?.title`

Consequently contentful assets that have empty description but a title (which works as the CMS label) will display a non empty `alt` attribute.

Proposed solution:
Introduce a way to make the `alt` attribute empty by setting the contentful asset's description field to a special value. In this PR I'm choosing the special value to be the string "null", reason for this is that the current decorative images in HFO's contentful space already have the description set to "null".