### PR TITLE
Add nullchecks to cloak-visual.coffee

### DIFF
--- a/components/cloak-visual.coffee
+++ b/components/cloak-visual.coffee
@@ -85,7 +85,7 @@ export default
 
 		# Use the width as the size if passed
 		sizes = if !props.sizes and props.width
-			if String(props.width).match /^\d+$/
+			if String(props.width)?.match /^\d+$/
 			then "#{props.width}px" # If width a number, treat as "px"
 			else props.width
 		else props.sizes
@@ -98,7 +98,7 @@ export default
 		# is of a format that woulds support transparency.  The latter is handy
 		# for product images.
 		placeholderColor = unless props.noPlaceholder or
-			(props.autoNoPlaceholder and props.image.match /\.(png|svg)/i)
+			(props.autoNoPlaceholder and props.image?.match /\.(png|svg)/i)
 		then process.env.PLACEHOLDER_COLOR || 'rgba(0,0,0,.2)'
 
 		# Disable lazy loading automatically if found in 2 blocks. Written

--- a/components/cloak-visual.coffee
+++ b/components/cloak-visual.coffee
@@ -85,7 +85,7 @@ export default
 
 		# Use the width as the size if passed
 		sizes = if !props.sizes and props.width
-			if String(props.width)?.match /^\d+$/
+			if String(props.width).match /^\d+$/
 			then "#{props.width}px" # If width a number, treat as "px"
 			else props.width
 		else props.sizes


### PR DESCRIPTION
During `yarn generate` on HFO I got this error (below).  I solved it by adding nullchecks here.  Not sure what exactly caused it, but I figure it never hurts to add more nullchecks.

<img width="974" alt="image" src="https://user-images.githubusercontent.com/6802815/166563748-fac3ef17-d510-40aa-8d14-06dcfbe51f7f.png">
