### PR TITLE
Fix bug where cloak doesn't generate any routes at all when CONTENTFUL_PREVIEW=true

### DIFF
--- a/config/concerns/cms.coffee
+++ b/config/concerns/cms.coffee
@@ -2,6 +2,7 @@
 Add configuration required to interact with CMS choice
 ###
 { join } = require 'path'
+{ getAccessToken } = require '../../services/contentful'
 module.exports = ({ cms }) ->
 	return unless cms
 
@@ -19,11 +20,7 @@ module.exports = ({ cms }) ->
 					CONTENTFUL_PREVIEW: process.env.CONTENTFUL_PREVIEW
 
 					# Don't expose the preview access token when it's not being used
-					CONTENTFUL_ACCESS_TOKEN: do ->
-						if process.env.CONTENTFUL_PREVIEW and
-							previewToken = process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN
-						then previewToken
-						else process.env.CONTENTFUL_ACCESS_TOKEN
+					CONTENTFUL_ACCESS_TOKEN: getAccessToken()
 
 		)
 	}

--- a/services/contentful.coffee
+++ b/services/contentful.coffee
@@ -7,13 +7,19 @@ import axios from 'axios'
 # when services/contentful was imported from a Nuxt module
 nonEmpty = (array) -> array.filter (val) -> !!val
 
+export getAccessToken = ->
+	if process.env.CONTENTFUL_PREVIEW and
+		previewToken = process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN
+	then previewToken
+	else process.env.CONTENTFUL_ACCESS_TOKEN
+
 # Make a Contentful client
 client = axios.create
 	baseURL: 'https://graphql.contentful.com/content/v1/spaces/' +
 		process.env.CONTENTFUL_SPACE
 	headers:
 		'Content-Type': 'application/json'
-		'Authorization': 'Bearer ' + process.env.CONTENTFUL_ACCESS_TOKEN
+		'Authorization': 'Bearer ' + getAccessToken()
 
 # Retry requests when met with Contentful API rate limits.
 # https://www.contentful.com/developers/docs/references/graphql/#/introduction/api-rate-limits


### PR DESCRIPTION
I upgraded HFO to cloak `^1.15.3`, and now the staging site doesn't generate any routes at all.  I poked around and it looks like `cloak/services/contentful.coffee` uses the wrong token when it generates routes.  (See screenshot below).  

To solve this, I extracted the contentful token logic from `cms.coffee` and put it in a shared function so that `contentful.coffee` can use it too.  Now when I test locally, craft generates the preview routes as intended.  Maybe you have a better pattern in mind for doing this, but having a fix for this would be great.

![image](https://user-images.githubusercontent.com/6802815/166564145-5a6594c5-eba2-4c49-92e7-96cde9148abd.png)
