### PR TITLE
Visual preload tags

### DIFF
--- a/components/contentful-visual.coffee
+++ b/components/contentful-visual.coffee
@@ -2,9 +2,6 @@
 import CloakVisual, { resizeWidths } from './cloak-visual'
 import { makeContentfulImageUrl } from '../services/helpers'
 
-# Image quality options
-imageQuality = {quality: process.env.IMAGE_QUALITY}
-
 # Map Contentful image objects into params for visual
 export default
 	name: 'ContentfulVisual'
@@ -28,7 +25,7 @@ export default
 
 		# Get the image src, ignoring srcset for now.  We're using the
 		imageUrl = if props.natural then image?.url
-		else makeContentfulImageUrl image?.url, resizeWidths[0], imageQuality
+		else makeContentfulImageUrl image?.url, resizeWidths[0]
 
 		# Figure out the aspect ratio
 		aspect = switch
@@ -92,8 +89,7 @@ export makeSrcset = (image, { webp, max } = {}) ->
 		resizeWidths.filter (size) -> size <= maxWidth
 
 	# Set webp format
-
-	options = if webp then { format: 'webp', ...imageQuality} else imageQuality
+	options = if webp then { format: 'webp' }
 
 	# Make the srcset string
 	sizes.map (size) ->

--- a/components/contentful-visual.coffee
+++ b/components/contentful-visual.coffee
@@ -2,6 +2,9 @@
 import CloakVisual, { resizeWidths } from './cloak-visual'
 import { makeContentfulImageUrl } from '../services/helpers'
 
+# Image quality options
+imageQuality = {quality: process.env.IMAGE_QUALITY}
+
 # Map Contentful image objects into params for visual
 export default
 	name: 'ContentfulVisual'
@@ -25,7 +28,7 @@ export default
 
 		# Get the image src, ignoring srcset for now.  We're using the
 		imageUrl = if props.natural then image?.url
-		else makeContentfulImageUrl image?.url, resizeWidths[0]
+		else makeContentfulImageUrl image?.url, resizeWidths[0], imageQuality
 
 		# Figure out the aspect ratio
 		aspect = switch
@@ -89,7 +92,8 @@ export makeSrcset = (image, { webp, max } = {}) ->
 		resizeWidths.filter (size) -> size <= maxWidth
 
 	# Set webp format
-	options = if webp then { format: 'webp' }
+
+	options = if webp then { format: 'webp', ...imageQuality} else imageQuality
 
 	# Make the srcset string
 	sizes.map (size) ->

--- a/mixins/visual/responsive-visual.vue
+++ b/mixins/visual/responsive-visual.vue
@@ -19,6 +19,27 @@ export default
 		portraitVideo: Object
 	}
 
+	head: ->
+		return {} unless @isResponsive and @preload
+
+		return link: [
+			{
+				rel: 'preload'
+				as: 'image'
+				imagesrcset: @makeSrcset @landscape.props.image
+				href: @landscape.props.image
+				imagesizes: @sizes
+			}
+
+			{
+				rel: 'preload'
+				as: 'image'
+				imagesrcset: @makeSrcset @portrait.props.image
+				href: @portrait.props.image
+				imagesizes: @sizes
+			}
+		]
+
 	data: ->
 		mounted: false
 		isLandscape: null

--- a/mixins/visual/responsive-visual.vue
+++ b/mixins/visual/responsive-visual.vue
@@ -22,6 +22,8 @@ export default
 	head: ->
 		return {} unless @isResponsive and @preload
 
+		console.log('responsive visual, making head tags, landscape is', @landscape, 'portrait is', @portrait)
+
 		return link: [
 			{
 				rel: 'preload'
@@ -29,6 +31,7 @@ export default
 				imagesrcset: @makeSrcset @landscape.props.image
 				href: @landscape.props.image
 				imagesizes: @sizes
+				'data-ref': 'landscape',
 			}
 
 			{
@@ -36,7 +39,8 @@ export default
 				as: 'image'
 				imagesrcset: @makeSrcset @portrait.props.image
 				href: @portrait.props.image
-				imagesizes: @sizes
+				imagesizes: @sizes,
+				'data-ref': 'portrait',
 			}
 		]
 

--- a/mixins/visual/responsive-visual.vue
+++ b/mixins/visual/responsive-visual.vue
@@ -20,7 +20,7 @@ export default
 	}
 
 	head: ->
-		return {} unless @landscape?.props?.image and @portrait?.props?.image and @preload
+		return {} unless @isResponsiveImage
 
 		return link: [
 			{
@@ -56,6 +56,7 @@ export default
 		@isLanscapeMediaQuery?.removeListener @checkIsLandscape
 
 	computed:
+		isResponsiveImage: -> !!@landscape?.props?.image and !!@portrait?.props?.image and @preload
 
 		# Visual configs
 		landscape: -> @makeConfig @getAsset('image', 'landscape'),
@@ -133,13 +134,19 @@ export default
 
 		# Make the config object for the create function by keeping all data and
 		# props except for replacing landscape and portrait with the asset itself
+		# and removing preload tag in case it was added
 		makeConfig: (image, video) ->
 			return unless image or video
+
+			# Don't pass preload to visual instance if we are adding responsive preload
+			preload = if @isResponsiveImage then false else @$props.preload
+
 			on: loaded: => @$emit 'loaded'
 			props: {
 				...@$props
 				image
 				video
+				preload
 				landscapeImage: undefined
 				portraitImage: undefined
 				landscapeVideo: undefined

--- a/mixins/visual/responsive-visual.vue
+++ b/mixins/visual/responsive-visual.vue
@@ -27,18 +27,18 @@ export default
 				rel: 'preload'
 				as: 'image'
 				imagesrcset: @makeSrcset @landscape.props.image
-				href: @landscape.props.image
+				href: @landscape?.props?.image?.url
 				imagesizes: @sizes
-				'data-ref': 'landscape',
+				media: '(orientation: landscape)'
 			}
 
 			{
 				rel: 'preload'
 				as: 'image'
 				imagesrcset: @makeSrcset @portrait.props.image
-				href: @portrait.props.image
+				href: @portrait?.props?.image?.url
 				imagesizes: @sizes,
-				'data-ref': 'portrait',
+				media: '(orientation: portrait)',
 			}
 		]
 

--- a/mixins/visual/responsive-visual.vue
+++ b/mixins/visual/responsive-visual.vue
@@ -20,9 +20,7 @@ export default
 	}
 
 	head: ->
-		return {} unless @isResponsive and @preload
-
-		console.log('responsive visual, making head tags, landscape is', @landscape, 'portrait is', @portrait)
+		return {} unless @landscape?.props?.image and @portrait?.props?.image and @preload
 
 		return link: [
 			{

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"stylus": "^0.54.0",
 		"stylus-loader": "^3.0.0",
 		"vue-routing-anchor-parser": "^1.8.0",
-		"vue-visual": "^2.0.0",
+		"vue-visual": "https://github.com/BKWLD/vue-visual#support-preload",
 		"webpack-cli": "^3.0.0",
 		"webpack-graphql-loader": "gpoitch/graphql-loader#gp/refresh"
 	},


### PR DESCRIPTION
Adding support for responsive preload tags. Will update the linked `vue-visual` package to point to the main branch once https://github.com/BKWLD/vue-visual/pull/76 is merged, so that should be reviewed first. 