### PR TITLE
Use Cloudflare’s poylfill service

### DIFF
--- a/config/concerns/polyfill.coffee
+++ b/config/concerns/polyfill.coffee
@@ -6,7 +6,7 @@ module.exports = ({ polyfills }) ->
 	# Use Polyfill.io for most polyfills
 	head: script: [
 		do ->
-			src = 'https://polyfill.io/v3/polyfill.min.js?features=' +
+			src = 'https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=' +
 				polyfills.join '%2C'
 			{ hid: 'polyfill', src, body: true }
 	]


### PR DESCRIPTION
https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet